### PR TITLE
warden.json

### DIFF
--- a/chains/mainnet/warden
+++ b/chains/mainnet/warden
@@ -1,0 +1,18 @@
+{
+  "chain_name": "warden",
+  "api": ["https://warden-testnet-api.hibunode.com"],
+  "rpc": ["https://warden-testnet-rpc.hibunode.com"],
+  "coin_type": 118,
+  "min_tx_fee": 200,
+  "sdk_version": "v0.50.9-evmos-warden",
+  "addr_prefix": "warden",
+  "logo": "/logos/warden.png",
+  "assets": [
+    {
+      "base": "award",
+      "symbol": "WARD",
+      "exponent": 18,
+      "logo": "/logos/warden.png"
+    }
+  ]
+}


### PR DESCRIPTION
{
  "chain_name": "warden",
  "api": ["https://warden-testnet-api.hibunode.com"],
  "rpc": ["https://warden-testnet-rpc.hibunode.com"],
  "coin_type": 118,
  "min_tx_fee": 200,
  "sdk_version": "v0.50.9-evmos-warden",
  "addr_prefix": "warden",
  "logo": "/logos/warden.png",
  "assets": [
    {
      "base": "award",
      "symbol": "WARD",
      "exponent": 18,
      "logo": "/logos/warden.png"
    }
  ]
}